### PR TITLE
Set output buffer explicitly

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "multicnnclassifier",
     "Manufacturer": "IDS Imaging Development Systems GmbH",
-    "Version": "1.2.0",
+    "Version": "1.2.1",
     "Type": "VApp",
     "Language":
     {

--- a/myvision.cpp
+++ b/myvision.cpp
@@ -17,7 +17,8 @@ void MyVision::process() {
                 // process image with deep ocean core.
                 // Scale the image to the input size of the cnn. If you don't scale it the NXT Framework will do scaling
                 // which can lower performance
-                _result[cnn] = cnn.cnnData.processImage(img->getQImage().copy(cnn.roi).scaled(cnn.cnnData.inputSize()));
+                _result[cnn] = cnn.cnnData.processImage(img->getQImage().copy(cnn.roi).scaled(cnn.cnnData.inputSize()),
+                                                        QStringLiteral("Classification"));
             }
 
             img->visionOK("", "");


### PR DESCRIPTION
If the output buffer is not explicitly specified, the result of a classification may be incorrect if a classification CNN that supports heatmaps is used.