### PR TITLE
Support new CNN file extensions

### DIFF
--- a/cnnroihandler.cpp
+++ b/cnnroihandler.cpp
@@ -21,7 +21,9 @@ CnnRoiHandler::CnnRoiHandler()
     _roiManager.setMaxROIs(CnnRoiConfig::getMaxRois());
     _cnnRoiConfigFile.setFilter({"Json |*.json"});
     _cnnRoiConfigFile.setDeletable(true);
-    _cnnFile.setFilter({"IDS CNN File |*.cnn"});
+    QList<TranslatedText> filtercnn;
+    filtercnn.append("IDS NXT rio/rome classification model |*.rcla; *.cnn");
+    _cnnFile.setFilter(filtercnn);
     _cnnFile.setDeletable(true);
     // Connect framework signals to local slot
     connect(&CnnManager::getInstance(), &CnnManager::cnnChanged, this, &CnnRoiHandler::cnnChanged);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "multicnnclassifier",
     "Manufacturer": "IDS Imaging Development Systems GmbH",
-    "Version": "1.2.1",
+    "Version": "3.1.0",
     "Type": "VApp",
     "Language":
     {

--- a/multicnnclassifier.pro
+++ b/multicnnclassifier.pro
@@ -23,7 +23,7 @@ DEFINES +=
 DISTFILES += README.md
 
 #Mandatory params
-NXT_SDK = 2.4.0
+NXT_SDK = 3.1.0
 AVATAR = avatar.png
 MANIFEST = manifest.json
 TRANSLATION = translation.json


### PR DESCRIPTION
Added the new file extension ".rcla" to the configurable file filter for the CNN upload.
With NXT 3.1.0 the file extensions were adjusted. The new file extensions for CNNs trained for IDS NXT OS Version 3.1.0 for IDS NXT rio and IDS NXT rome are *.rcla, *.rdet and *.rano.